### PR TITLE
Fix name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Latest Release](https://img.shields.io/github/release/dexlose/jax-wallet.svg)](https://github.com/dexlose/jax-wallet/releases)
 [![License: MIT](https://img.shields.io/github/license/dexlose/jax-wallet.svg)](https://github.com/dexlose/jax-wallet/blob/main/LICENSE)
 
-# Jaxx Wallet
+# Jax Wallet
 
-**Jaxx Wallet** is a user-friendly cryptocurrency wallet that supports multiple coins, offers enhanced security, and provides a clean, intuitive interface.
+**Jax Wallet** is a user-friendly cryptocurrency wallet that supports multiple coins, offers enhanced security, and provides a clean, intuitive interface.
 
 ---
 
@@ -36,9 +36,9 @@
 1. **Download the appropriate installer** from the [Releases](https://github.com/dexlose/jax-wallet/releases) page.
 2. **Install the application** following your operating system’s standard installation process.
    - **Windows**: Run the downloaded `.exe` file and follow the setup wizard.
-   - **macOS**: Open the `.dmg` file and drag **Jaxx Wallet** into the Applications folder.
+   - **macOS**: Open the `.dmg` file and drag **Jax Wallet** into the Applications folder.
    - **Linux**: Make the `.AppImage` executable and run it.
-3. **Launch Jaxx Wallet** and start managing your cryptocurrencies.
+3. **Launch Jax Wallet** and start managing your cryptocurrencies.
 
 ---
 
@@ -64,4 +64,4 @@ We appreciate your feedback! If you encounter any issues or have suggestions, pl
 - **Create an issue** on GitHub, or 
 - **Submit a pull request** if you have a fix or improvement.
 
-Thank you for using **Jaxx Wallet**! 
+Thank you for using **Jax Wallet**! 


### PR DESCRIPTION
## Summary
- update outdated references to "Jaxx Wallet" in README

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6849551ddb14832992f846105eac02ca